### PR TITLE
Fixes mysql8 errors

### DIFF
--- a/setup/tools/sqlgen/creature.func.php
+++ b/setup/tools/sqlgen/creature.func.php
@@ -33,7 +33,7 @@ SqlGen::register(new class extends SetupScript
                 exp,
                 faction,
                 npcflag,
-                IF(rank > 4, 0, rank),
+                IF(`rank` > 4, 0, `rank`),
                 dmgSchool,
                 DamageModifier,
                 BaseAttackTime,


### PR DESCRIPTION
Escape "rank" as it's considered a keyword in MySQL 8, throwing an error.

Error message before this commit:
![image](https://user-images.githubusercontent.com/1153754/75184326-82149100-5744-11ea-8d67-fa6c97c7a058.png)

Message after this commit:
![image](https://user-images.githubusercontent.com/1153754/75184351-8e005300-5744-11ea-979a-1e41dc845718.png)
