### PR TITLE
[Fix] .htaccess - php_value

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -15,7 +15,6 @@ Order Deny,Allow
 </Files>
 
 # Block view of some folders
-Options -Indexes
 DirectoryIndex index.php
 
 # Support for UTF8
@@ -24,10 +23,6 @@ AddDefaultCharset utf8
     CharsetDisable on
     CharsetRecodeMultipartForms Off
 </IfModule>
-
-# UHD screenshots can get pretty large (cannot be set in config)
-    php_value       upload_max_filesize                         20M
-    php_value       post_max_size                               25M
 
 RewriteEngine on
 # RewriteBase /~user/localPath/     # enable if the rules do not work, when they should


### PR DESCRIPTION
Newer PHP Version's don't use these php_values in .htaccess

Options -Indexes Not anymore used really!