### PR TITLE
fix(dbc-name): remove conversion to lowercase of dbc file name

### DIFF
--- a/setup/tools/dbc.class.php
+++ b/setup/tools/dbc.class.php
@@ -264,7 +264,6 @@ class DBC
 
     public function __construct($file, $opts = [])
     {
-        $file = strtolower($file);
         if (empty($this->_fields[$file]) || empty($this->_formats[$file]))
         {
             CLI::write('no structure known for '.$file.'.dbc, aborting.', CLI::LOG_ERROR);


### PR DESCRIPTION
The OS unix-like, like Linux are case-sensitive, so if you do not remove this conversion the OS running PHP will not find the files and you can get the following error:
```
[ERR]   no suitable files found for achievement_category.dbc, aborting.
```