### PR TITLE
bug in ruru

### DIFF
--- a/includes/types/spell.class.php
+++ b/includes/types/spell.class.php
@@ -771,7 +771,7 @@ class SpellList extends BaseType
             $str .= implode(', ', $runes);
         }
         else if ($this->curTpl['powerCostPercent'] > 0)     // power cost: pct over static
-            $str .= $this->curTpl['powerCostPercent']."% ".sprintf(Lang::spell('pctCostOf'), strtolower(Lang::spell('powerTypes', $pt)));
+            $str .= $this->curTpl['powerCostPercent']."% ".sprintf(Lang::spell('pctCostOf'), mb_strtolower(Lang::spell('powerTypes', $pt)));
         else if ($this->curTpl['powerCost'] > 0 || $this->curTpl['powerPerSecond'] > 0 || $this->curTpl['powerCostPerLevel'] > 0)
             $str .= ($pt == POWER_RAGE || $pt == POWER_RUNIC_POWER ? $this->curTpl['powerCost'] / 10 : $this->curTpl['powerCost']).' '.Util::ucFirst(Lang::spell('powerTypes', $pt));
 


### PR DESCRIPTION
Perhaps you know more, but without mb_strtolower(), I get an empty tooltip and an erroneous encoding in the Russian locale, like screenshot: 
![image](https://user-images.githubusercontent.com/25082773/109510704-ea731c80-7ad4-11eb-8b21-e845257ef2e0.png)
After adding mb_strtolower(), the problem disappears, maybe you know what the problem is?
PHP 7.3.27