### PR TITLE
fix: remove useless static method getName() in SoundList, close #293

### DIFF
--- a/includes/types/sound.class.php
+++ b/includes/types/sound.class.php
@@ -60,13 +60,6 @@ class SoundList extends BaseType
         }
     }
 
-    public static function getName($id)
-    {
-        $this->getEntry($id);
-
-        return $this->getField('name');
-    }
-
     public function getListviewData()
     {
         $data = [];


### PR DESCRIPTION
Close #293