### PR TITLE
Update smartAI.class.php

### DIFF
--- a/includes/smartAI.class.php
+++ b/includes/smartAI.class.php
@@ -1267,7 +1267,7 @@ class SmartAI
                 $a['param'][6] = $this->aiTemplate($a['param'][0]);
                 break;
             case SAI_ACTION_TELEPORT:                       // 62 -> invoker [resolved coords already stored in areatrigger entry]
-                $a['param'][6] = $this->miscData['teleportA'];
+                $a['param'][6] = $this->miscData['name'];
                 $this->jsGlobals[Type::ZONE][] = $a['param'][6];
                 break;
             case SAI_ACTION_SET_ORIENTATION:                // 66 -> any target


### PR DESCRIPTION
```Undefined index: teleportA```
When debugging, I found what is called "name" , example:
```
array(1) {
  ["name"]=>
  string(37) "Инициатор Тероккара"
}
```
PHP:
```php
            case SAI_ACTION_TELEPORT:                       // 62 -> invoker [resolved coords already stored in areatrigger entry]
                var_dump($this->miscData); //debug
                $a['param'][6] = $this->miscData['teleportA'];
                $this->jsGlobals[TYPE_ZONE][] = $a['param'][6];
                break;
```