### PR TITLE
added info about supported php versions in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also, this project is not meant to be used for commercial puposes of any kind!
 
 ## Requirements
 
-+ Webserver running PHP ≥ 7.4 — 8.0 including extensions:
++ Webserver running PHP ≥ 7.4 (7.4 works with version [v1.1](https://github.com/Sarjuuk/aowow/releases/tag/v1.1))  — 8.1.x (works with version [v1.2](https://github.com/Sarjuuk/aowow/releases/tag/v1.2)) including extensions:
   + [SimpleXML](https://www.php.net/manual/en/book.simplexml.php)
   + [GD](https://www.php.net/manual/en/book.image)
   + [MySQL Improved](https://www.php.net/manual/en/book.mysqli.php)


### PR DESCRIPTION
Based on this [issue](https://github.com/Sarjuuk/aowow/issues/347) , added info to readme.md, so anybody can clearly see that version v1.1 works with php 7.4.26 (but not with v1.2) and version v1.2 can work up to PHP 8.1.6. (in my case). 

Thank you for info regarding php versions.
Tested on Debian11.


