### PR TITLE
fix: "Cannot access protected property SpellList::$sources"

### DIFF
--- a/includes/basetype.class.php
+++ b/includes/basetype.class.php
@@ -845,7 +845,7 @@ trait profilerHelper
 
 trait sourceHelper
 {
-    protected $sources    = [];
+    public $sources    = [];
     protected $sourceMore = null;
 
     public function getSources(?array &$s = [], ?array &$sm = []) : bool


### PR DESCRIPTION
Due to encapsulation, some child object can't access properly to `SpellList::$sources`.
```
Error: Cannot access protected property SpellList::$sources in /home/user/aowow/pages/spell.php:1097 Stack trace: #0 /home/user/aowow/pages/genericPage.class.php(410): SpellPage->generateContent() #1 /home/user/aowow/pages/genericPage.class.php(775): GenericPage->prepareContent() #2 /home/user/aowow/index.php(135): GenericPage->display() #3 {main}
```

This is the reason why wowgaming didn't load some spells correctly.

I do not know why db.rising-gods.de do not encounter the same issue, I think that some PHP 8.x version could be more "strict" on this checks OR I did something wrong during the ac/aowow alignment with sarjuuk/aowow.

### BEFORE the fix:

<img width="974" alt="image" src="https://github.com/user-attachments/assets/0f633fd2-e979-4b27-ab14-781b6865d533" />

### AFTER the fix:

<img width="995" alt="image" src="https://github.com/user-attachments/assets/0d230a5c-ea0b-4d57-9753-26edf57d49be" />