### PR TITLE
wrap php_value directives in IfModule blocks

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -26,8 +26,10 @@ AddDefaultCharset utf8
 </IfModule>
 
 # UHD screenshots can get pretty large (cannot be set in config)
+<IfModule mod_php.c>
     php_value       upload_max_filesize                         20M
     php_value       post_max_size                               25M
+</IfModule>
 
 RewriteEngine on
 # RewriteBase /~user/localPath/     # enable if the rules do not work, when they should


### PR DESCRIPTION
This is necessary to avoid a 500 error if you are not using mod_php (for example, if you use php-fpm)