### PR TITLE
fix typo in TrImageProcessor::writeImageFile

### DIFF
--- a/setup/tools/setupScript.class.php
+++ b/setup/tools/setupScript.class.php
@@ -307,7 +307,7 @@ trait TrImageProcessor
             imagefill($outRes, 0, 0, $transparentindex);
         }
 
-        imagecopyresampled($outRes, $src, $destDims['x'], $destDims['x'], $srcDims['x'], $srcDims['y'], $destDims['w'], $destDims['h'], $srcDims['w'], $srcDims['h']);
+        imagecopyresampled($outRes, $src, $destDims['x'], $destDims['y'], $srcDims['x'], $srcDims['y'], $destDims['w'], $destDims['h'], $srcDims['w'], $srcDims['h']);
 
         switch ($ext)
         {


### PR DESCRIPTION
x is used twice instead of first x and then y

(I think it doesn't affect anything since it's always called with coords 0, 0)