### PR TITLE
Fix composer file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "dibi/dibi": "^5.1",
-        "php": "8.4 - 8.6",
+        "php": "^8.4",
         "ext-mbstring": "*",
         "ext-simplexml": "*",
         "ext-gd": "*",

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
         "ext-intl": "*"
     },
     "require-dev": {
-        "jfcherng/php-diff": "6.16"
+        "jfcherng/php-diff": "^6.16"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20cef922a03920a90b2661df1379b91e",
+    "content-hash": "a076983e412f18945edf2b9634ac8930",
     "packages": [
         {
             "name": "dibi/dibi",
@@ -145,16 +145,16 @@
         },
         {
             "name": "jfcherng/php-diff",
-            "version": "6.16.0",
+            "version": "6.16.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jfcherng/php-diff.git",
-                "reference": "8b49edeba6e367df22977fca0f0324b4a99b78a0"
+                "reference": "6d7332b6080cdd50011a364b58f24c8d0cdeb5da"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jfcherng/php-diff/zipball/8b49edeba6e367df22977fca0f0324b4a99b78a0",
-                "reference": "8b49edeba6e367df22977fca0f0324b4a99b78a0",
+                "url": "https://api.github.com/repos/jfcherng/php-diff/zipball/6d7332b6080cdd50011a364b58f24c8d0cdeb5da",
+                "reference": "6d7332b6080cdd50011a364b58f24c8d0cdeb5da",
                 "shasum": ""
             },
             "require": {
@@ -164,7 +164,7 @@
                 "php": ">=7.4"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.8",
+                "friendsofphp/php-cs-fixer": "^3.51",
                 "liip/rmt": "^1.6",
                 "phan/phan": "^5",
                 "phpunit/phpunit": "^9",
@@ -199,7 +199,7 @@
             ],
             "support": {
                 "issues": "https://github.com/jfcherng/php-diff/issues",
-                "source": "https://github.com/jfcherng/php-diff/tree/6.16.0"
+                "source": "https://github.com/jfcherng/php-diff/tree/6.16.3"
             },
             "funding": [
                 {
@@ -207,7 +207,7 @@
                     "type": "custom"
                 }
             ],
-            "time": "2024-03-05T08:44:05+00:00"
+            "time": "2026-06-22T13:08:56+00:00"
         },
         {
             "name": "jfcherng/php-mb-string",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bc01e51b92b3c763d2d359212cface97",
+    "content-hash": "20cef922a03920a90b2661df1379b91e",
     "packages": [
         {
             "name": "dibi/dibi",
@@ -328,7 +328,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "8.4 - 8.6",
+        "php": "^8.4",
         "ext-mbstring": "*",
         "ext-simplexml": "*",
         "ext-gd": "*",


### PR DESCRIPTION
Hello, there is few fixes for `composer.json` file:

**Issue 1:** PHP version constraint in composer requirements:
It's better to set it using caret operator `^8.4` (means `>=8.4,<9`), it defines minimum required version and allows to use the project with higher versions of PHP (8.5, 8.6, etc.). See https://getcomposer.org/doc/articles/versions.md#next-significant-release-operators for details.

~~**Issue 2:** missed `ffi` extension. I don't know what this is required exactly for, but after upgrade PHP from `8.2` to `8.4` setup script raises an error:~~

```
# php ./aowow
Required Extension ffi was not found. Please check if it should exist, using "php -m"
```

~~May be it's required appropriate fix in code instead ?~~

**Issue 3:** `composer update` will not update dependency to the latest version because constraint is hardcoded.
Version operator `^` should be used according to https://semver.org/ (Standard de-facto for libraries).
See https://getcomposer.org/doc/articles/versions.md#next-significant-release-operators for details.

For information:

- `composer install` installs dependencies from `composer.lock` file
- `composer update` updates dependencies from `composer.json` and generates new `composer.lock` file

Change will not affect the current dependency version, but will fix `composer update` command for use in the future.
