### PR TITLE
fix: prevent XSS — escape setting data for javascript code

### DIFF
--- a/template/pages/home.tpl.php
+++ b/template/pages/home.tpl.php
@@ -17,8 +17,8 @@
     <div id="layers"></div>
 
 <?php
-if ($this->homeTitle):
-    echo "    <script>document.title = '".$this->homeTitle."';</script>".PHP_EOL;
+if (!empty($this->homeTitle) && is_string($this->homeTitle)):
+    echo "    <script>document.title = " . json_encode($this->homeTitle) . ";</script>".PHP_EOL;
 endif;
 
 if ($this->altHomeLogo):


### PR DESCRIPTION
Hello, there is fix for `home.tpl.php` file:

**Issue 1:** XSS
First what I saw after aowow install is JS syntax error because of putting the title of website (with unescaped quote characters) into JS script on page. Required to be fixed. I decided to take this issue fix from #450, because it awaits almost one year there.
