### PR TITLE
fix: access policy for internal files

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,11 +1,3 @@
-<Files "aowow">
-    ForceType application/x-httpd-php
-</Files>
-
-<Files "prQueue">
-    ForceType application/x-httpd-php
-</Files>
-
 # Block view of some folders
 Options -Indexes
 

--- a/.htaccess
+++ b/.htaccess
@@ -1,11 +1,3 @@
-Order Deny,Allow
-<FilesMatch "\.(conf|php|in)$">
-    Deny from all
-</FilesMatch>
-<FilesMatch "^(index)\.php$">
-    Allow from all
-</FilesMatch>
-
 <Files "aowow">
     ForceType application/x-httpd-php
 </Files>
@@ -16,7 +8,6 @@ Order Deny,Allow
 
 # Block view of some folders
 Options -Indexes
-DirectoryIndex index.php
 
 # Support for UTF8
 AddDefaultCharset utf8
@@ -32,6 +23,19 @@ AddDefaultCharset utf8
 </IfModule>
 
 RewriteEngine on
+
+# Allow index.php to handle root requests
+RewriteRule ^$ index.php [L]
+
+# Allow specific files
+RewriteRule ^(index\.php|crossdomain\.xml|robots\.txt)$ - [L,NC]
+
+# Allow static assets
+RewriteRule ^static/.*$ - [L,NC]
+
+# Block everything else
+RewriteRule ^ - [F,L]
+
 # RewriteBase /~user/localPath/     # enable if the rules do not work, when they should
 
 # Mapper-Helper: If you cant provide maps for all locales, redirect the browser


### PR DESCRIPTION
Hello,
serving website with Apache makes internal files and directories accessible for client.
Here is a fix of this issue.

Few examples of files accessible for client:

- .git/HEAD
- composer.json
- composer.lock
- datasets/statistics
- setup/sql/01-db_structure.sql

It's better to deny everything by default and allow only public entrypoints OR:
Ideally is to make `public` directory and place public entrypoints there, and switch base directory for webserver to there.

What do you think?